### PR TITLE
Make "tutorial" open in same tab

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -30,7 +30,7 @@ class Home extends React.Component {
         <Content.Left>
           <Title.Primary>WidgetBot</Title.Primary>
           <Title.Secondary>Discord widgets for your website</Title.Secondary>
-          <Button.Primary href="https://docs.widgetbot.io/tutorial" target="_blank" rel="noopener">
+          <Button.Primary href="https://docs.widgetbot.io/tutorial" rel="noopener">
             Tutorial
           </Button.Primary>
           <Button.Secondary href="https://discord.gg/8zYvp6W" target="_blank" rel="noopener">


### PR DESCRIPTION
It's a little annoying having to close the other tab. The tutorial is what most people would end up going on anyways, so there's no reason to open the link in a new tab.